### PR TITLE
Add FloodWaitError import

### DIFF
--- a/start.py
+++ b/start.py
@@ -32,6 +32,7 @@ from backend.functions import (
 from backend.json_into_html import generate_html_from_json
 from telethon import functions, types
 from telethon.sync import TelegramClient
+from telethon.errors import FloodWaitError
 
 # Create an ArgumentParser object
 parser = argparse.ArgumentParser(description='Custom settings for script launch')


### PR DESCRIPTION
Good afternoon!

There was a critical error in the project: in the file start.py the FloodWaitError was not imported, which caused an error:

```bash
Traceback (most recent call last):
  File "/home/alex/code/CCTV/start.py", line 152, in <module>
    except FloodWaitError as e:
           ^^^^^^^^^^^^^^
NameError: name 'FloodWaitError' is not defined
```

I fixed this error by adding the necessary import
